### PR TITLE
Set <title> for the options page

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Brick Break Anywhere - Webページ崩し</title>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
Hello, canalun! I got interested in this super fun project to learn how to manipulate DOM more fluently. I'm going to read the code and send pull requests if possible. To begin with, I've configured the `<title>` of options.html.

- Before this change: `__MSG_extensionName__`
- And now: `Brick Break Anywhere - Webページ崩し`

The new title is copied from its `<h1>` tags. Suggest if you like another one.

Ref. https://docs.plasmo.com/framework/customization/html