### PR TITLE
i18n the title of the option page

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4,5 +4,8 @@
   },
   "extensionDescription": {
     "message": "Turn any webpage into an impromptu brick-breaking game!"
+  },
+  "optionPageTitle": {
+    "message": "Brick Break Anywhere"
   }
 }

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -4,5 +4,8 @@
   },
   "extensionDescription": {
     "message": "どんなwebページもブロックくずしに早変わり！"
+  },
+  "optionPageTitle": {
+    "message": "Webページ崩し"
   }
 }

--- a/src/options.html
+++ b/src/options.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>Brick Break Anywhere - Webページ崩し</title>
-  </head>
-  <body>
-  </body>
-</html>

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -2,8 +2,12 @@ import addedIcon from "data-base64:../assets/added_icon.png"
 import extListIcon from "data-base64:../assets/ext_list_icon.png"
 import pin from "data-base64:../assets/pin.png"
 import startButton from "data-base64:../assets/start_button.png"
+import { useEffect } from "react"
 
 function NewTab() {
+  useEffect(() => {
+    document.title = chrome.i18n.getMessage("optionPageTitle")
+  }, [])
   return (
     <>
       <h1>Brick Break Anywhere</h1>


### PR DESCRIPTION
i18n the title of the option page with Plasmo i18n API.
https://docs.plasmo.com/framework/locales#inside-source-code-modules

It might be a bit aggressive to set `document.title` directly.
But I think it has no problem, because the page is not related to SEO.