### PR TITLE
Fix: debug mode also shouldn't start multiple times + Refactor

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -50,6 +50,6 @@ chrome.runtime.onMessage.addListener(function(message) {
   if (window.document.readyState === "complete") {
     mainOrDebug()
   } else {
-    window.addEventListener("load", () => {mainOrDebug()})
+    window.addEventListener("load", mainOrDebug)
   }
 })

--- a/src/content.ts
+++ b/src/content.ts
@@ -22,29 +22,34 @@ export {}
 chrome.runtime.sendMessage(createContentIsReadyMessage())
 
 let started = false // prevent multiple execution
-chrome.runtime.onMessage.addListener(function (message) {
-  if (!started && isMessageStartMessage(message)) {
-    // Use the "complete" event rather than the "interactive",
-    // because document.body is required for exec `preventScroll()`,
-    // and block calculation should be executed after iframes have been loaded.
-    if (window.document.readyState === "complete") {
-      started = true
-      main(message.options)
-    } else {
-      started = true
-      window.addEventListener("load", () => {
-        main(message.options)
-      })
-    }
-  }
-})
+chrome.runtime.onMessage.addListener(function(message) {
 
-if (process.env.NODE_ENV === "development") {
-  chrome.runtime.onMessage.addListener(function (message) {
-    if (isMessageTestMessage(message)) {
+  let mainOrDebug: () => void;
+  if (isMessageStartMessage(message)) {
+    mainOrDebug = () => main(message.options)
+  } else if (isMessageTestMessage(message)) {
+    mainOrDebug = () => {
       const blocks = getBlocks()
       visualizeBlocks(blocks)
+      main({withScoreboard : false, initialBallSpeed : "middle"})
       dragAndMoveBall(blocks)
     }
-  })
-}
+  } else {
+    return
+  }
+
+  // Check and mark as started only when the message is "start" or "test".
+  if (started) {
+    return
+  }
+  started = true
+
+  // Use the "complete" event rather than the "interactive",
+  // because document.body is required for exec `preventScroll()`,
+  // and block calculation should be executed after iframes have been loaded.
+  if (window.document.readyState === "complete") {
+    mainOrDebug()
+  } else {
+    window.addEventListener("load", () => {mainOrDebug()})
+  }
+})

--- a/src/game/debug.ts
+++ b/src/game/debug.ts
@@ -6,13 +6,13 @@ import {
   collisionPointOnBallClass,
   numberOfCollisionPoints
 } from "./configuration/settings"
-import { main } from "./main"
 import {
   getBallCenterPosition,
   getCurrentCollisionPointsOnBall,
   type Ball
 } from "./object/ball"
 import type { Block } from "./object/blocks"
+import { assert } from "./utils/dom"
 import type { Vector } from "./utils/vector"
 
 // This file contains tools only for debug.
@@ -72,12 +72,8 @@ export function updateVisualizedCollisionPointsOnBall(
 }
 
 export function dragAndMoveBall(blocks: Block[]) {
-  main({ withScoreboard: false, initialBallSpeed: "middle" })
-
   const ball = document.getElementById(ballId)
-  if (!ball) {
-    return
-  }
+  assert(ball !== null, "ball element must be found")
 
   startBlockAndScoreUpdate(blocks, null)
 


### PR DESCRIPTION
Merge if you like!

1. Before this change, the debug mode starts even after all blocks are removed. I think both the standard mode and debug mode are treated as same. Then I abstract them.
    - NOTE: Remove judging if `NODE_ENV === "development"` because I think hiding the "debug mode" button is sufficient.
2. Refactor: It's confusing that `dragAndMoveBall` calls `main`. I couldn't figure out from the name