### PR TITLE
🆕 Option to mute sound

### DIFF
--- a/src/game/configuration/settings.ts
+++ b/src/game/configuration/settings.ts
@@ -9,6 +9,7 @@ export const collisionPointOnBallClass = "bba-collision-point-on-ball"
 export type StartOptions = {
   withScoreboard: boolean
   initialBallSpeed: "low" | "middle" | "high" | "superHigh"
+  sound: boolean
 }
 
 type BarSetting = {

--- a/src/game/start/standby.ts
+++ b/src/game/start/standby.ts
@@ -20,7 +20,7 @@ export function standby(
   scoreboard: Scoreboard | null,
   startOptions: StartOptions
 ) {
-  const ring = setSoundEffect()
+  const ring = startOptions.sound ? setSoundEffect() : () => {}
 
   window.addEventListener("mousemove", moveBarAndBall)
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -18,6 +18,7 @@ function IndexPopup() {
   ) => {
     setInitialBallSpeed(e.target.value as StartOptions["initialBallSpeed"])
   }
+  const [sound, setSound] = useState(true)
 
   const sendMessageToIsolatedWorldOnActiveTab = () => {
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
@@ -27,7 +28,7 @@ function IndexPopup() {
       }
       chrome.tabs.sendMessage<StartMessage>(
         activeTab.id,
-        createStartMessage({ withScoreboard, initialBallSpeed })
+        createStartMessage({ withScoreboard, initialBallSpeed, sound })
       )
     })
   }
@@ -113,6 +114,25 @@ function IndexPopup() {
             type="radio"
             checked={!withScoreboard}
             onChange={(e) => setWithScoreboard(!e.target.checked)}
+          />
+          Off
+        </label>
+      </div>
+      <div style={{ marginTop: "16px" }}>
+        Sound {sound ? "🔊" : "🔇"}<br />
+        <label>
+          <input
+            type="radio"
+            checked={sound}
+            onChange={(e) => setSound(e.target.checked)}
+          />
+          On
+        </label>
+        <label>
+          <input
+            type="radio"
+            checked={!sound}
+            onChange={(e) => setSound(!e.target.checked)}
           />
           Off
         </label>


### PR DESCRIPTION
Background
====

As an average player/debugger (and a fun of some live streamers), I want to play/debug the game while watching a YouTube live etc. Playing sound is a little annoying in such a usecase.

Suggestion
====

Add an option to mute the sound of the game.

Screenshot
====

ON:

![image](https://github.com/canalun/brick-break-anywhere/assets/227057/7146e3e6-67ca-45c9-bcf8-c3a3921fa721)

OFF:

![image](https://github.com/canalun/brick-break-anywhere/assets/227057/ff2c7b33-d976-45ca-948e-bf7f539caed6)
