### PR TITLE
Make (equivalent for) dragAndMoveBall available again

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,6 @@
 import {
   createReplayIsConfirmedOnBackgroundMessage,
+  createStartMessage,
   isMessageContentIsReadyMessage,
   isMessageRequestReplayToBackgroundMessage
 } from "~message"
@@ -26,7 +27,7 @@ chrome.runtime.onMessage.addListener((message, sender) => {
       ) {
         chrome.tabs.sendMessage(
           _senderTabId,
-          message.message
+          createStartMessage(message.options)
         )
       }
       chrome.runtime.onMessage.removeListener(startReplay)

--- a/src/content.ts
+++ b/src/content.ts
@@ -27,17 +27,14 @@ chrome.runtime.onMessage.addListener(function(message) {
 
   let mainOrDebug: () => void;
   if (isMessageStartMessage(message)) {
-    mainOrDebug = () => main(message)
+    mainOrDebug = () => main(message.options)
   } else if (isMessageTestMessage(message)) {
     mainOrDebug = () => {
       const blocks = getBlocks()
       visualizeBlocks(blocks)
       main({
-        type: "test",
-        options: {
-          ...message.options,
-          withScoreboard: false
-        }
+        ...message.options,
+        withScoreboard : false
       })
       dragAndMoveBall(blocks)
     }
@@ -47,7 +44,7 @@ chrome.runtime.onMessage.addListener(function(message) {
 
   // Check and mark as started only when the message is "start" or "test".
   if (started) {
-    replay(message)
+    replay(message.options)
     return
   }
   started = true

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,4 +1,3 @@
-import { disableScoreboardIfDebug } from "~game/configuration/settings"
 import { replay } from "~game/end/gameOver"
 import { main } from "~game/main"
 import {
@@ -38,10 +37,10 @@ chrome.runtime.onMessage.addListener(function(message) {
   // because document.body is required for exec `preventScroll()`,
   // and block calculation should be executed after iframes have been loaded.
   if (window.document.readyState === "complete") {
-    main(disableScoreboardIfDebug(message.options))
+    main(message.options)
   } else {
     window.addEventListener("load", () => {
-      main(disableScoreboardIfDebug(message.options))
+      main(message.options)
     })
   }
 })

--- a/src/game/animation/startBallAnimation.ts
+++ b/src/game/animation/startBallAnimation.ts
@@ -1,16 +1,14 @@
 import {
-  ballSetting,
   getInitialBallSpeed,
   initialBallDirection,
   type StartOptions
 } from "../configuration/settings"
 import type { Ball } from "../object/ball"
-import { getBallCenterPosition } from "../object/ball"
 import type { Bar } from "../object/bar"
 import type { Block } from "../object/blocks"
 import type { Vector } from "../utils/vector"
 import { getVectorMultipliedWithScalar } from "../utils/vector"
-import { getUpdatedBallDirection, getUpdatedBallSpeed } from "./updateBall"
+import { getUpdatedBallDirection, getUpdatedBallSpeed, updateBallPositionBy } from "./updateBall"
 
 export function startBallAnimation(
   ball: Ball,
@@ -31,7 +29,7 @@ export function startBallAnimation(
   })
   function updateBall(ball: Ball): void {
     updateBallVelocity(ball)
-    updateBallPosition(ball)
+    updateBallPositionBy(ball, currentBallVelocity)
     id = requestAnimationFrame(() => updateBall(ball))
   }
 
@@ -40,17 +38,6 @@ export function startBallAnimation(
     window.addEventListener("click", stopBallAnimation)
   }
   return stopBallAnimation
-
-  function updateBallPosition(ball: Ball): void {
-    const currentBallPosition = getBallCenterPosition(ball)
-    Object.assign(ball.style, {
-      transform:
-        `translate(` +
-        `${currentBallPosition.x - ballSetting.radius + currentBallVelocity.x}px, ` +
-        `${-(currentBallPosition.y - ballSetting.radius + currentBallVelocity.y)}px` +
-        `)`
-    })
-  }
 
   function updateBallVelocity(ball: Ball): void {
     // acceleration

--- a/src/game/animation/updateBall.ts
+++ b/src/game/animation/updateBall.ts
@@ -1,5 +1,6 @@
 import {
   ballAcceleration,
+  ballSetting,
   barSetting,
   maximumLimitOfBallSpeed,
   redundancyOfCollisionWithBar,
@@ -19,7 +20,7 @@ import {
   type Vector
 } from "../utils/vector"
 
-export function getUpdatedBallSpeed(currentBallSpeed: number) {
+export function getUpdatedBallSpeed(currentBallSpeed: number): number {
   return Math.min(currentBallSpeed + ballAcceleration, maximumLimitOfBallSpeed)
 }
 
@@ -220,4 +221,25 @@ export function updateBallDirectionByCollisionWithBlocks(
     }
   }
   return { x: currentBallDirection.x, y: currentBallDirection.y }
+}
+
+export function updateBallPositionBy(ball: Ball, velocity: Vector): void {
+  const currentBallPosition = getBallCenterPosition(ball)
+  Object.assign(ball.style, {
+    transform:
+    `translate(` +
+      `${currentBallPosition.x - ballSetting.radius + velocity.x}px, ` +
+      `${-(currentBallPosition.y - ballSetting.radius + velocity.y)}px` +
+      `)`
+  })
+}
+
+export function updateBallPositionTo(ball: Ball, position: { x: number, y: number }): void {
+  Object.assign(ball.style, {
+    transform:
+    `translate(` +
+      `${position.x}px, ` +
+      `${position.y}px` +
+      `)`
+  })
 }

--- a/src/game/animation/updateBall.ts
+++ b/src/game/animation/updateBall.ts
@@ -20,6 +20,8 @@ import {
   type Vector
 } from "../utils/vector"
 
+export { updateObjectPositionTo as updateBallPositionTo } from "./updateObject"
+
 export function getUpdatedBallSpeed(currentBallSpeed: number): number {
   return Math.min(currentBallSpeed + ballAcceleration, maximumLimitOfBallSpeed)
 }
@@ -230,17 +232,6 @@ export function updateBallPositionBy(ball: Ball, velocity: Vector): void {
     `translate(` +
       `${currentBallPosition.x - ballSetting.radius + velocity.x}px, ` +
       `${-(currentBallPosition.y - ballSetting.radius + velocity.y)}px` +
-      `)`
-  })
-}
-
-// TODO: Also available for Bar?
-export function updateBallPositionTo(ball: Ball, position: { x: number, y: number }): void {
-  Object.assign(ball.style, {
-    transform:
-    `translate(` +
-      `${position.x}px, ` +
-      `${position.y}px` +
       `)`
   })
 }

--- a/src/game/animation/updateBall.ts
+++ b/src/game/animation/updateBall.ts
@@ -234,6 +234,7 @@ export function updateBallPositionBy(ball: Ball, velocity: Vector): void {
   })
 }
 
+// TODO: Also available for Bar?
 export function updateBallPositionTo(ball: Ball, position: { x: number, y: number }): void {
   Object.assign(ball.style, {
     transform:

--- a/src/game/animation/updateBar.ts
+++ b/src/game/animation/updateBar.ts
@@ -1,0 +1,1 @@
+export { updateObjectPositionTo as updateBarPositionTo } from "./updateObject"

--- a/src/game/animation/updateObject.ts
+++ b/src/game/animation/updateObject.ts
@@ -1,5 +1,5 @@
-export function updateObjectPositionTo(ball: HTMLDivElement, position: { x: number, y: number }): void {
-  Object.assign(ball.style, {
+export function updateObjectPositionTo(obj: HTMLDivElement, position: { x: number, y: number }): void {
+  Object.assign(obj.style, {
     transform:
     `translate(` +
       `${position.x}px, ` +

--- a/src/game/animation/updateObject.ts
+++ b/src/game/animation/updateObject.ts
@@ -1,0 +1,9 @@
+export function updateObjectPositionTo(ball: HTMLDivElement, position: { x: number, y: number }): void {
+  Object.assign(ball.style, {
+    transform:
+    `translate(` +
+      `${position.x}px, ` +
+      `${position.y}px` +
+      `)`
+  })
+}

--- a/src/game/configuration/settings.ts
+++ b/src/game/configuration/settings.ts
@@ -14,16 +14,6 @@ export type StartOptions = {
   controlMode: "normal" | "mouse"
 }
 
-export function disableScoreboardIfDebug(options: StartOptions): StartOptions {
-  if (options.visualizeBlocks || options.controlMode === "mouse") {
-    return {
-      ...options,
-      withScoreboard: false
-    }
-  }
-  return options
-}
-
 type BarSetting = {
   width: number
   height: number

--- a/src/game/configuration/settings.ts
+++ b/src/game/configuration/settings.ts
@@ -9,7 +9,19 @@ export const collisionPointOnBallClass = "bba-collision-point-on-ball"
 export type StartOptions = {
   withScoreboard: boolean
   initialBallSpeed: "low" | "middle" | "high" | "superHigh"
-  sound: boolean
+  sound: boolean,
+  visualizeBlocks: boolean,
+  controlMode: "normal" | "mouse"
+}
+
+export function disableScoreboardIfDebug(options: StartOptions): StartOptions {
+  if (options.visualizeBlocks || options.controlMode === "mouse") {
+    return {
+      ...options,
+      withScoreboard: false
+    }
+  }
+  return options
 }
 
 type BarSetting = {

--- a/src/game/end/gameOver.ts
+++ b/src/game/end/gameOver.ts
@@ -1,12 +1,12 @@
 import {
   createRequestReplayToBackgroundMessage,
-  isMessageReplayIsConfirmedOnBackgroundMessage,
-  type AnyStartMessage,
+  isMessageReplayIsConfirmedOnBackgroundMessage
 } from "~message"
 
 import {
   ballSetting,
   veilZIndex,
+  type StartOptions
 } from "../configuration/settings"
 import { getBallCenterPosition, type Ball } from "../object/ball"
 import type { Block } from "../object/blocks"
@@ -14,7 +14,7 @@ import type { Block } from "../object/blocks"
 export function startCheckIsGameOver(
   ball: Ball,
   blocks: Block[],
-  message: AnyStartMessage,
+  options: StartOptions,
   stopAnimationFuncs: (() => void)[]
 ) {
   requestAnimationFrame(checkIsGameOver)
@@ -23,13 +23,13 @@ export function startCheckIsGameOver(
     const isBallTouchBottom =
       getBallCenterPosition(ball).y - ballSetting.radius <= 0
     if (isBallTouchBottom) {
-      gameOver(blocks, message)
+      gameOver(blocks, options)
       stopAnimationFuncs.forEach((f) => f())
       return
     }
     const isAllBlocksDestroyed = !blocks.some((b) => b.remain)
     if (isAllBlocksDestroyed) {
-      gameOver(blocks, message)
+      gameOver(blocks, options)
       stopAnimationFuncs.forEach((f) => f())
       return
     }
@@ -37,7 +37,7 @@ export function startCheckIsGameOver(
   }
 }
 
-function gameOver(blocks: Block[], message: AnyStartMessage) {
+function gameOver(blocks: Block[], options: StartOptions) {
   const countOfBrokenBlocks = blocks.filter((b) => !b.remain).length
 
   const gameOverMessage = document.createElement("div")
@@ -77,17 +77,17 @@ function gameOver(blocks: Block[], message: AnyStartMessage) {
   })
   replayButton.textContent = "Replay"
   replayButton.onclick = () => {
-    replay(message)
+    replay(options)
   }
   gameOverMessage.appendChild(replayButton)
 }
 
-export function replay(message: AnyStartMessage) {
+export function replay(options: StartOptions) {
   chrome.runtime.onMessage.addListener((message) => {
     if (isMessageReplayIsConfirmedOnBackgroundMessage(message)) {
       location.reload()
     }
   })
 
-  chrome.runtime.sendMessage(createRequestReplayToBackgroundMessage(message))
+  chrome.runtime.sendMessage(createRequestReplayToBackgroundMessage(options))
 }

--- a/src/game/main.ts
+++ b/src/game/main.ts
@@ -1,3 +1,4 @@
+import { visualizeBlocks } from "~game/debug"
 import { displayMessageInConsole } from "./configuration/easterEggs"
 import type { StartOptions } from "./configuration/settings"
 import { freezePage } from "./start/freezePage"
@@ -10,6 +11,11 @@ export function main(options: StartOptions) {
   try {
     freezePage()
     const { ball, bar, blocks, scoreboard } = initializeObjects(options)
+
+    if (options.visualizeBlocks) {
+      visualizeBlocks(blocks)
+    }
+
     standby(ball, bar, blocks, scoreboard, options)
   } catch (e) {
     console.log(e)

--- a/src/game/main.ts
+++ b/src/game/main.ts
@@ -1,16 +1,16 @@
-import type { AnyStartMessage } from "~message"
 import { displayMessageInConsole } from "./configuration/easterEggs"
+import type { StartOptions } from "./configuration/settings"
 import { freezePage } from "./start/freezePage"
 import { initializeObjects } from "./start/initializeObjects"
 import { standby } from "./start/standby"
 
-export function main(message: AnyStartMessage) {
+export function main(options: StartOptions) {
   displayMessageInConsole()
 
   try {
     freezePage()
-    const { ball, bar, blocks, scoreboard } = initializeObjects(message.options)
-    standby(ball, bar, blocks, scoreboard, message)
+    const { ball, bar, blocks, scoreboard } = initializeObjects(options)
+    standby(ball, bar, blocks, scoreboard, options)
   } catch (e) {
     console.log(e)
   }

--- a/src/game/start/standby.ts
+++ b/src/game/start/standby.ts
@@ -14,6 +14,7 @@ import type { Bar } from "../object/bar"
 import type { Block } from "../object/blocks"
 import type { Scoreboard } from "../object/scoreboard"
 import { updateBallPositionTo } from "~game/animation/updateBall"
+import { updateBarPositionTo } from "~game/animation/updateBar"
 
 export function standby(
   ball: Ball,
@@ -54,11 +55,10 @@ export function standby(
   })
 
   function moveBarAndBall(e: MouseEvent) {
-    bar.style.transform =
-      `translate(` +
-      `${e.clientX - barSetting.width / 2}px, ` +
-      `${-initialBottom}px` +
-      `)`
+    updateBarPositionTo(bar, {
+      x: e.clientX - barSetting.width / 2,
+      y: -initialBottom
+    });
     updateBallPositionTo(ball, {
       x: e.clientX - ballSetting.radius,
       y: -(initialBottom + barSetting.height)

--- a/src/game/start/standby.ts
+++ b/src/game/start/standby.ts
@@ -1,10 +1,10 @@
-import type { AnyStartMessage } from "~message"
 import { startBallAnimation } from "../animation/startBallAnimation"
 import { startBlockAndScoreUpdate } from "../animation/updateBlocks"
 import {
   ballSetting,
   barSetting,
   initialBottom,
+  type StartOptions
 } from "../configuration/settings"
 import { setSoundEffect } from "../configuration/soundEffect"
 import { startCheckIsGameOver } from "../end/gameOver"
@@ -18,9 +18,8 @@ export function standby(
   bar: Bar,
   blocks: Block[],
   scoreboard: Scoreboard | null,
-  startMessage: AnyStartMessage
+  startOptions: StartOptions
 ) {
-  const startOptions = startMessage.options
   const ring = startOptions.sound ? setSoundEffect() : () => {}
 
   window.addEventListener("mousemove", moveBarAndBall)
@@ -41,7 +40,7 @@ export function standby(
     )
     const stopBlockAndScoreUpdate = startBlockAndScoreUpdate(blocks, scoreboard)
 
-    startCheckIsGameOver(ball, blocks, startMessage, [
+    startCheckIsGameOver(ball, blocks, startOptions, [
       stopBallAnimation,
       stopBlockAndScoreUpdate,
       () => {

--- a/src/game/start/standby.ts
+++ b/src/game/start/standby.ts
@@ -1,3 +1,4 @@
+import { controlBallByMouse } from "~game/debug"
 import { startBallAnimation } from "../animation/startBallAnimation"
 import { startBlockAndScoreUpdate } from "../animation/updateBlocks"
 import {
@@ -12,6 +13,7 @@ import type { Ball } from "../object/ball"
 import type { Bar } from "../object/bar"
 import type { Block } from "../object/blocks"
 import type { Scoreboard } from "../object/scoreboard"
+import { updateBallPositionTo } from "~game/animation/updateBall"
 
 export function standby(
   ball: Ball,
@@ -31,13 +33,15 @@ export function standby(
 
     window.addEventListener("mousemove", moveBar)
 
-    const stopBallAnimation = startBallAnimation(
-      ball,
-      bar,
-      blocks,
-      startOptions.initialBallSpeed,
-      ring
-    )
+    const stopBallAnimation = startOptions.controlMode === "normal"
+      ? startBallAnimation(
+          ball,
+          bar,
+          blocks,
+          startOptions.initialBallSpeed,
+          ring
+        )
+      : controlBallByMouse(blocks)
     const stopBlockAndScoreUpdate = startBlockAndScoreUpdate(blocks, scoreboard)
 
     startCheckIsGameOver(ball, blocks, startOptions, [
@@ -53,13 +57,12 @@ export function standby(
     bar.style.transform =
       `translate(` +
       `${e.clientX - barSetting.width / 2}px, ` +
-      `${-1 * initialBottom}px` +
+      `${-initialBottom}px` +
       `)`
-    ball.style.transform =
-      `translate(` +
-      `${e.clientX - ballSetting.radius}px, ` +
-      `${-(initialBottom + barSetting.height)}px` +
-      `)`
+    updateBallPositionTo(ball, {
+      x: e.clientX - ballSetting.radius,
+      y: -(initialBottom + barSetting.height)
+    })
   }
 
   function moveBar(e: MouseEvent) {

--- a/src/message.ts
+++ b/src/message.ts
@@ -35,8 +35,6 @@ export function isMessageTestMessage(message: any): message is TestMessage {
   return message.type === test
 }
 
-export type AnyStartMessage = StartMessage | TestMessage
-
 // For replay, this game uses three kinds of messages.
 // 1. RequestReplayToBackgroundMessage
 // 2. ReplayIsConfirmedOnBackgroundMessage
@@ -44,15 +42,15 @@ export type AnyStartMessage = StartMessage | TestMessage
 const requestReplayToBackground = "requestReplayToBackground"
 type RequestReplayToBackgroundMessage = {
   type: typeof requestReplayToBackground
-  message: AnyStartMessage
+  options: StartOptions
 }
 
 export function createRequestReplayToBackgroundMessage(
-  message: AnyStartMessage
+  options: StartOptions
 ): RequestReplayToBackgroundMessage {
   return {
     type: requestReplayToBackground,
-    message
+    options
   }
 }
 

--- a/src/message.ts
+++ b/src/message.ts
@@ -17,24 +17,6 @@ export function isMessageStartMessage(message: any): message is StartMessage {
   return message.type === start
 }
 
-// For start debug mode.
-const test = "test"
-export type TestMessage = {
-  type: typeof test
-  options: StartOptions
-}
-
-export function createTestMessage(options: StartOptions): TestMessage {
-  return {
-    type: test,
-    options
-  }
-}
-
-export function isMessageTestMessage(message: any): message is TestMessage {
-  return message.type === test
-}
-
 // For replay, this game uses three kinds of messages.
 // 1. RequestReplayToBackgroundMessage
 // 2. ReplayIsConfirmedOnBackgroundMessage

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -17,6 +17,7 @@ function IndexPopup() {
     setInitialBallSpeed(e.target.value as StartOptions["initialBallSpeed"])
   }
   const [sound, setSound] = useState(true)
+  const [debug, setDebug] = useState(false)
 
   const sendMessageToIsolatedWorldOnActiveTab = () => {
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
@@ -27,7 +28,7 @@ function IndexPopup() {
       chrome.tabs.sendMessage<StartMessage>(
         activeTab.id,
         createStartMessage({
-          withScoreboard,
+          withScoreboard: withScoreboard && !debug,
           initialBallSpeed,
           sound,
           visualizeBlocks: false,
@@ -35,6 +36,7 @@ function IndexPopup() {
         })
       )
     })
+    window.close()
   }
 
   const sendMessageToIsolatedWorldOnActiveTabForTest = () => {
@@ -46,7 +48,7 @@ function IndexPopup() {
       chrome.tabs.sendMessage<StartMessage>(
         activeTab.id,
         createStartMessage({
-          withScoreboard,
+          withScoreboard: false,
           initialBallSpeed,
           sound,
           visualizeBlocks: true,
@@ -57,6 +59,14 @@ function IndexPopup() {
     })
   }
 
+  const start = () => {
+    if (debug) {
+      sendMessageToIsolatedWorldOnActiveTabForTest()
+    } else {
+      sendMessageToIsolatedWorldOnActiveTab()
+    }
+  }
+
   return (
     <div
       style={{
@@ -65,13 +75,7 @@ function IndexPopup() {
         padding: "16px"
       }}>
       <h2>Brick Break Anywhere</h2>
-      <button
-        onClick={() => {
-          sendMessageToIsolatedWorldOnActiveTab()
-          window.close()
-        }}>
-        Start!
-      </button>
+      <button onClick={start}> Start! </button>
       <br />
       <div style={{ marginTop: "16px" }}>
         Initial Ball Speed <br />
@@ -117,6 +121,7 @@ function IndexPopup() {
         <label>
           <input
             type="radio"
+            disabled={debug}
             checked={withScoreboard}
             onChange={(e) => setWithScoreboard(e.target.checked)}
           />
@@ -125,6 +130,7 @@ function IndexPopup() {
         <label>
           <input
             type="radio"
+            disabled={debug}
             checked={!withScoreboard}
             onChange={(e) => setWithScoreboard(!e.target.checked)}
           />
@@ -150,12 +156,29 @@ function IndexPopup() {
           Off
         </label>
       </div>
-      <br />
       {process.env.NODE_ENV === "development" ? (
-        <button onClick={sendMessageToIsolatedWorldOnActiveTabForTest}>
-          debug mode
-        </button>
+        <div style={{ marginTop: "16px" }}>
+          Debug Mode<br />
+          <label>
+            <input
+              type="radio"
+              checked={debug}
+              onChange={(e) => setDebug(e.target.checked)}
+            />
+            On
+          </label>
+          <label>
+            <input
+              type="radio"
+              checked={!debug}
+              onChange={(e) => setDebug(!e.target.checked)}
+            />
+            Off
+          </label>
+        </div>
       ) : null}
+      <br />
+      <button onClick={start}> Start! </button>
     </div>
   )
 }

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -3,9 +3,7 @@ import { useState } from "react"
 import type { StartOptions } from "~game/configuration/settings"
 import {
   createStartMessage,
-  createTestMessage,
   type StartMessage,
-  type TestMessage
 } from "~message"
 
 function IndexPopup() {
@@ -28,7 +26,13 @@ function IndexPopup() {
       }
       chrome.tabs.sendMessage<StartMessage>(
         activeTab.id,
-        createStartMessage({ withScoreboard, initialBallSpeed, sound })
+        createStartMessage({
+          withScoreboard,
+          initialBallSpeed,
+          sound,
+          visualizeBlocks: false,
+          controlMode: "normal"
+        })
       )
     })
   }
@@ -39,9 +43,15 @@ function IndexPopup() {
       if (!activeTab.id) {
         return
       }
-      chrome.tabs.sendMessage<TestMessage>(
+      chrome.tabs.sendMessage<StartMessage>(
         activeTab.id,
-        createTestMessage({ withScoreboard, initialBallSpeed, sound })
+        createStartMessage({
+          withScoreboard,
+          initialBallSpeed,
+          sound,
+          visualizeBlocks: true,
+          controlMode: "mouse"
+        })
       )
       window.close()
     })


### PR DESCRIPTION
~~This is still draft because I left a several things below and I want to show you before completing to reduce the risk in case of refusal.~~ **FEEDBACK WELCOME!**

- ~~More customizable debugging mode: make `controlMode` and `visualizeBlocks` separately configurable on popup.html.~~ See https://github.com/canalun/brick-break-anywhere/pull/15#discussion_r1650971230 on why I removed this.
- [x] Refactor: apply `updateBallPositionTo` to other objects if possible and it deserves.

Background
====

When I first play with brick-block-anywhere on [my website](https://the.igreque.info/), I found a bug that could be a good chance for me to learn the browser's behavior. This feature is very useful for reproducing the bug and testing after fixing it.

Changes Summary
====

- Add a function `controlBallByMouse` to move the ball by mouse so that we can easily put the ball at some place for debugging.
- Abstract the procedure to move the ball (`updateBallPositionBy` and `updateBallPositionTo`) to hide the details and for consistency.
- Merge `TestMessage` into `StartMessage` because now the non-debugging mode has to know whether the debugging mode is enabled to disable the default movement of the ball.
    - Bonus: this change also makes https://github.com/canalun/brick-break-anywhere/commit/12c7f5388700581a373decda998a4bffbf957668  unnecessary. It's simpler!

Screenshot
====

![bba-control-by-mouse](https://github.com/canalun/brick-break-anywhere/assets/227057/8b7658c3-8bad-4f67-a88f-1be1c58f4a0a)