### PR TITLE
chore: remove tabs permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "typescript": "5.3.3"
   },
   "manifest": {
-    "permissions": [
-      "tabs"
-    ],
     "host_permissions": [
       "<all_urls>"
     ],


### PR DESCRIPTION
the `tabs` permission is not required...!

https://developer.chrome.com/docs/webstore/troubleshooting/#excessive-permissions

> tabs
> **This permission ONLY grants access to the url, pendingUrl, title, or favIconUrl properties of Tab objects.**
> When is it required?
> When an extension does not have broad host access, but needs to be able to read sensitive data like the URL of an arbitrary tab.
> When is it NOT required?
> When using methods on the [tabs](https://developer.chrome.com/docs/extensions/reference/tabs) API.
> When the extension has access to broad host permissions. Host permissions grant the extension access to the same data as well as other capabilities.