### PR TITLE
Fix: Blocks shifts by the border's size when removed or debug mode enabled

### DIFF
--- a/src/game/animation/updateBlocks.ts
+++ b/src/game/animation/updateBlocks.ts
@@ -42,8 +42,8 @@ export function startBlockAndScoreUpdate(
 function removeBlockAndUpdateBlocksPosition(block: Block, blocks: Block[]) {
   // make to-be-removed element red just a moment before removing it
   const element = block.element as HTMLElement // TODO: remove type assertion
-  const originalBorderWidth = getComputedStyleWithCache(element).borderWidth
-  element.style.border = `${originalBorderWidth === "0px" ? "1px" : originalBorderWidth} solid red`
+  const originalOutlineWidth = getComputedStyleWithCache(element).outlineWidth
+  element.style.outline = `${originalOutlineWidth === "0px" ? "1px" : originalOutlineWidth} solid red`
 
   setTimeout(() => {
     removeBlock(block)

--- a/src/game/animation/updateBlocks.ts
+++ b/src/game/animation/updateBlocks.ts
@@ -42,8 +42,12 @@ export function startBlockAndScoreUpdate(
 function removeBlockAndUpdateBlocksPosition(block: Block, blocks: Block[]) {
   // make to-be-removed element red just a moment before removing it
   const element = block.element as HTMLElement // TODO: remove type assertion
-  const originalOutlineWidth = getComputedStyleWithCache(element).outlineWidth
-  element.style.outline = `${originalOutlineWidth === "0px" ? "1px" : originalOutlineWidth} solid red`
+  const originalBorderWidth = getComputedStyleWithCache(element).borderWidth
+  if (originalBorderWidth === "0px") {
+    element.style.outline = `1px solid red`
+  } else {
+    element.style.border = `${originalBorderWidth} solid red`
+  }
 
   setTimeout(() => {
     removeBlock(block)

--- a/src/game/animation/updateBlocks.ts
+++ b/src/game/animation/updateBlocks.ts
@@ -44,7 +44,7 @@ function removeBlockAndUpdateBlocksPosition(block: Block, blocks: Block[]) {
   const element = block.element as HTMLElement // TODO: remove type assertion
   const originalBorderWidth = getComputedStyleWithCache(element).borderWidth
   if (originalBorderWidth === "0px") {
-    element.style.outline = `1px solid red`
+    element.style.outline = "1px solid red"
   } else {
     element.style.border = `${originalBorderWidth} solid red`
   }

--- a/src/game/debug.ts
+++ b/src/game/debug.ts
@@ -25,12 +25,12 @@ export function visualizeBlocks(blocks: Block[]) {
     if (blocks[i].remain) {
       ;(blockElement as HTMLElement).style && // TODO: remove type assertion
         Object.assign((blockElement as HTMLElement).style, {
-          border: "0.1px solid red"
+          outline: "0.1px solid red"
         })
     } else {
       ;(blockElement as HTMLElement).style && // TODO: remove type assertion
         Object.assign((blockElement as HTMLElement).style, {
-          border: "none"
+          outline: "none"
         })
     }
   }


### PR DESCRIPTION
# Problem

Blocks move right little by little when hit by the ball. It's not a problem when the number of blocks is small, but when the document contains many inline elements aligned in a block element, the rightmost element shifts significantly.

Here's an example reproduced by the `controlMode: "mouse"` feature created in https://github.com/canalun/brick-break-anywhere/pull/15, and hard-coding `visualizeBlocks: false` (checkout [my debug branch](https://github.com/igrep/brick-break-anywhere/tree/debug) if you reproduce by yourself):

![bba-unintentional-shift](https://github.com/canalun/brick-break-anywhere/assets/227057/c92bea31-033f-4c1d-a25d-fcebc19c1477)

As you can see, several right blocks shift so right that the ball breaks them without colliding. This is because the shifts make their actual positions differ from the positions managed by the game.

<details>
  <summary>The source of the screenshot HTML is here.</summary>

```html
<!DOCTYPE html>
<html>
  <head>
    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <meta http-equiv="Content-Language" content="ja">
  </head>
  <body>
    <span>0</span>
    <span>1</span>
    <span>2</span>
    <span>3</span>
    <span>4</span>
    <span>5</span>
    <span>6</span>
    <span>7</span>
    <span>8</span>
    <span>9</span>
    <span>a</span>
    <span>b</span>
    <span>c</span>
    <span>d</span>
    <span>e</span>
    <span>f</span>
    <span>g</span>
    <span>h</span>
    <span>i</span>
    <span>j</span>
    <span>k</span>
    <span>l</span>
    <span>m</span>
    <span>n</span>
    <span>o</span>
    <span>p</span>
    <span>q</span>
    <span>r</span>
    <span>s</span>
    <span>t</span>
    <span>u</span>
    <span>v</span>
    <span>w</span>
    <span>x</span>
    <span>y</span>
    <span>z</span>
    <span>A</span>
    <span>B</span>
    <span>C</span>
    <span>D</span>
    <span>E</span>
    <span>F</span>
    <span>G</span>
    <span>H</span>
    <span>I</span>
    <span>J</span>
    <span>K</span>
    <span>L</span>
    <span>M</span>
    <span>N</span>
    <span>O</span>
    <span>P</span>
    <span>Q</span>
    <span>R</span>
    <span>S</span>
    <span>T</span>
    <span>U</span>
    <span>V</span>
    <span>W</span>
    <span>X</span>
    <span>Y</span>
    <span>Z</span>
  </body>
</html>
```

</details>

# Solution

Use `outline` instead of `border` for highlighting block hit by the ball (or when debug mode).

# NOTE

I tested this change only in the example case and [my website's top page](https://the.igreque.info/). Tell me if you think of any side-effect.